### PR TITLE
refactor(web): use public common exports

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -17,3 +17,8 @@ export * from "./selectors";
 export * from "./services";
 export * from "./store";
 export * from "./validators";
+
+export * from "./providers/DataProvider/Internal/models/User/IUsersInAssetListModel";
+export * from "./providers/DataProvider/Internal/models/User/IUsersListModel";
+export * from "./store/auth/types";
+export * from "./store/configuration/selectors";

--- a/packages/web/src/components/Events/Events.tsx
+++ b/packages/web/src/components/Events/Events.tsx
@@ -3,7 +3,7 @@
  * @copyright Better Software Group S.A.
  * @version: 1.0
  */
-import { configurationSelector } from "@xala/common/src/store/configuration/selectors";
+import { configurationSelector } from "@xala/common";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";

--- a/packages/web/src/components/Forms/ConfirmAccountWithPassword/ConfirmAccountWithPassword.tsx
+++ b/packages/web/src/components/Forms/ConfirmAccountWithPassword/ConfirmAccountWithPassword.tsx
@@ -15,8 +15,8 @@ import {
   IUserDeviceModel,
   updateApiErrors,
   UrlHelper,
+  IAuthState,
 } from "@xala/common";
-import { IAuthState } from "@xala/common/src/store/auth/types";
 import React from "react";
 import { WithTranslation } from "react-i18next";
 import { RouteComponentProps } from "react-router";

--- a/packages/web/src/components/MediaCreator/CreatorsStep/CreatorsStep.tsx
+++ b/packages/web/src/components/MediaCreator/CreatorsStep/CreatorsStep.tsx
@@ -13,8 +13,8 @@ import {
   RecordStatus,
   useDataLoader,
   UserInAssetRoles,
+  IUsersInAssetListModel,
 } from "@xala/common";
-import { IUsersInAssetListModel } from "@xala/common/src/providers/DataProvider/Internal/models";
 import useForm from "rc-field-form/lib/useForm";
 import React, { useContext, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";

--- a/packages/web/src/components/UsersInAssetFieldList/UsersInAssetField.tsx
+++ b/packages/web/src/components/UsersInAssetFieldList/UsersInAssetField.tsx
@@ -7,8 +7,8 @@ import {
   IUserInAssetRoleModel,
   IUserModel,
   UserInAssetRoles,
+  IUsersListModel,
 } from "@xala/common";
-import { IUsersListModel } from "@xala/common/src/providers/DataProvider/Internal/models";
 import { ListField } from "rc-field-form/lib/List";
 import React from "react";
 import { useTranslation } from "react-i18next";

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -7,13 +7,5 @@
     "typeRoots": ["@types", "../../node_modules/@types"]
   },
   "include": ["src", "@types/index.d.ts"],
-  "exclude": ["node_modules", "public"],
-  "references": [
-    {
-      "path": "../common"
-    }
-  ],
-  "paths": {
-    "@xala/common": ["../common"]
-  },
+  "exclude": ["node_modules", "public"]
 }


### PR DESCRIPTION
## Summary
- remove local `@xala/common` references in web tsconfig
- use `@xala/common` public APIs instead of internal paths
- expose missing models and selectors from `@xala/common`

## Testing
- `npx tsc -b packages/common`
- `npx tsc -b packages/web` *(fails: Argument of type '{ FullTextSearch: string; IncludeCount: boolean; PageNumber: number; PageSize: number; AssetId: number; }' is not assignable to parameter of type 'IAssetsInAssetSearchFilterModel'.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e493c9c88324939d6ec35f43b7b4